### PR TITLE
tiltfile: remove some old feature flags/comments

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -89,7 +89,6 @@ docker_build('hypothesizer', 'hypothesizer',
   live_update=[
     sync('hypothesizer', '/app'),
     run('cd /app && pip install -r requirements.txt', trigger='hypothesizer/requirements.txt'),
-    # no restart_container needed because hypothesizer is a flask app which hot-reloads its code
   ]
 )
 docker_build_with_restart('fortune', 'fortune', '/go/bin/fortune',

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,8 +1,5 @@
 # -*- mode: Python -*-
 enable_feature("snapshots")
-enable_feature("events")
-
-k8s_resource_assembly_version(2)
 
 set_team("3e8e3af3-52e7-4f86-9006-9b1cce9ec85d")
 
@@ -74,8 +71,6 @@ docker_build('emoji', 'emoji')
 docker_build('words', 'words')
 docker_build('secrets', 'secrets')
 docker_build('sleep', 'sleeper')
-
-enable_feature('multiple_containers_per_pod')
 
 # we can add live_update steps on top of a docker_build for super fast in-place updates
 docker_build_with_restart('fe', 'fe', '/go/bin/fe',


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/clean-up-tiltfile:

5cf38b1a2b8dcca5d685b068637c439c168846ef (2020-07-07 18:23:58 -0400)
tiltfile: remove some old feature flags/comments

fdc248ccf57a590445e825dad21511e8147385f4 (2020-07-07 18:18:01 -0400)
remove a comment

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics