### PR TITLE
Ensure that username is lowercase

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -36,7 +36,7 @@ load('ext://restart_process', 'docker_build_with_restart')
 default_registry(read_json('tilt_option.json', {})
                  .get('default_registry', 'gcr.io/windmill-public-containers/servantes'))
 
-username = str(local('whoami')).rstrip('\n')
+username = str(local('whoami')).rstrip('\n').lower()
 
 def m4_yaml(file):
   read_file(file)


### PR DESCRIPTION
On my machine, my username is not lowercase and on first `tilt up` I hit this error for all but three of the services. 

`a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.`

Converting the username to lowercase resolves this issue.